### PR TITLE
Fixed very visible typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
     <!-- Main jumbotron for a primary marketing message or call to action -->
     <div class="jumbotron">
       <div class="container">
-        <h1 id="home">Mt. Ranier Information</h1>
+        <h1 id="home">Mt. Rainier Information</h1>
         <!-- TODO: Create an HTML structure that will trigger the Bootstrap
                    carousel feature. http://getbootstrap.com/javascript/#carousel
 


### PR DESCRIPTION
Title on page was written as "Ranier" instead of "Rainier"

<img width="267" alt="rainier" src="https://cloud.githubusercontent.com/assets/10458058/10856099/9953e934-7f02-11e5-80df-437e363cfb21.png">
